### PR TITLE
Add example: pot-led-chaser

### DIFF
--- a/examples/pot-led-chaser/pot-led-chaser.ino
+++ b/examples/pot-led-chaser/pot-led-chaser.ino
@@ -1,0 +1,35 @@
+/**
+ * Title: Pot LED Chaser
+ * Description: Turns on red, yellow, or green LED based on potentiometer position.
+ */
+
+#include "alpha.h"
+
+void setup()
+{
+ pinMode(AL_LED_RED, OUTPUT);
+ pinMode(AL_LED_YELLOW, OUTPUT);
+ pinMode(AL_LED_GREEN, OUTPUT);
+}
+
+void loop()
+{
+ int potVal = analogRead(AL_POT_A1); // 0–1023
+
+ digitalWrite(AL_LED_RED, LOW);
+ digitalWrite(AL_LED_YELLOW, LOW);
+ digitalWrite(AL_LED_GREEN, LOW);
+
+ if (potVal < 341)
+ {
+  digitalWrite(AL_LED_GREEN, HIGH);
+ }
+ else if (potVal < 682)
+ {
+  digitalWrite(AL_LED_YELLOW, HIGH);
+ }
+ else
+ {
+  digitalWrite(AL_LED_RED, HIGH);
+ }
+}


### PR DESCRIPTION
This example demonstrates how to control three LEDs using a potentiometer connected to the AL_POT_A1 pin.

As the user turns the potentiometer knob, the sketch reads the analog value (0–1023) and divides it into three ranges:
- Low range (0–340): the green LED turns ON
- Mid range (341–681): the yellow LED turns ON
- High range (682–1023): the red LED turns ON

Only one LED is on at a time depending on the potentiometer's position. This allows users to see a clear visual response to analog input, making it useful for demonstrating analog-to-digital conversion and simple control logic.

**Features:**
- Uses three LEDs: AL_LED_GREEN, AL_LED_YELLOW, AL_LED_RED
- Reads from AL_POT_A1
- Uses only predefined pin macros from `alpha.h`
- Sketch is located in `examples/pot-led-chaser/pot-led-chaser.ino`

This example is simple, beginner-friendly, and useful for understanding how to map analog input to digital output.
