### PR TITLE
Added Timer on Serial 

### DIFF
--- a/examples/serial-stopwatch/serial-stopwatch.ino
+++ b/examples/serial-stopwatch/serial-stopwatch.ino
@@ -1,0 +1,137 @@
+/**
+ * Title: Serial Stopwatch with LEDs & Audible Buzzer
+ * Description: Stopwatch with button control, LED indicators, buzzer tones, and serial display. Button A4 = Start/Pause/Resume  Button A5 = Reset
+ */
+
+#include "alpha.h"
+
+// State
+bool running = false;
+bool started = false;
+unsigned long startTime = 0;
+unsigned long elapsedTime = 0;
+
+// Button state tracking
+bool lastButtonA4 = HIGH;
+bool lastButtonA5 = HIGH;
+
+void setup() {
+  // Pin modes
+  pinMode(AL_BUTTON_A4, INPUT_PULLUP);
+  pinMode(AL_BUTTON_A5, INPUT_PULLUP);
+  pinMode(AL_BUZZER, OUTPUT);
+  pinMode(AL_LED_RED, OUTPUT);
+  pinMode(AL_LED_YELLOW, OUTPUT);
+  pinMode(AL_LED_GREEN, OUTPUT);
+
+  Serial.begin(9600);
+  delay(500);
+
+  Serial.println("== Serial Stopwatch ==");
+  Serial.println("Press Button A4 to start");
+
+  showStatus("stopped");
+}
+
+void loop() {
+  // Read buttons
+  bool buttonA4 = digitalRead(AL_BUTTON_A4);
+  bool buttonA5 = digitalRead(AL_BUTTON_A5);
+
+  // Handle A4 - Start/Pause/Resume
+  if (buttonA4 == LOW && lastButtonA4 == HIGH) {
+    if (!started) {
+      // Start the stopwatch
+      started = true;
+      running = true;
+      startTime = millis();
+      beepStart();
+      showStatus("running");
+      Serial.println("Running... Press A4 to pause, A5 to reset.");
+    } else {
+      // Toggle running state (pause/resume)
+      running = !running;
+      if (running) {
+        startTime = millis() - elapsedTime;
+        Serial.println("Resumed...");
+        showStatus("running");
+        beepStart();
+      } else {
+        elapsedTime = millis() - startTime;
+        Serial.println("Paused. Press A4 to resume, A5 to reset.");
+        showStatus("paused");
+        beepPause();
+      }
+    }
+    delay(200);  // debounce
+  }
+  lastButtonA4 = buttonA4;
+
+  // Handle A5 - Reset
+  if (buttonA5 == LOW && lastButtonA5 == HIGH && started) {
+    running = false;
+    started = false;
+    elapsedTime = 0;
+    Serial.println("== Stopwatch Reset ==");
+    Serial.println("Press Button A4 to start");
+    showStatus("stopped");
+    beepReset();
+    delay(200);  // debounce
+  }
+  lastButtonA5 = buttonA5;
+
+  // Update display if running
+  if (started && running) {
+    static unsigned long lastUpdate = 0;
+    if (millis() - lastUpdate >= 200) {
+      unsigned long current = millis() - startTime;
+      printTime(current);
+      lastUpdate = millis();
+    }
+  }
+}
+
+void printTime(unsigned long ms) {
+  unsigned int minutes = (ms / 60000) % 60;
+  unsigned int seconds = (ms / 1000) % 60;
+  unsigned int centis = (ms % 1000) / 10;
+
+  char buffer[16];
+  sprintf(buffer, "%02u:%02u.%02u", minutes, seconds, centis);
+  Serial.println(buffer);
+}
+
+// Audible tone functions
+void beepStart() {
+  tone(AL_BUZZER, 1000, 150);  // 1kHz tone for 150ms
+  delay(200);
+  noTone(AL_BUZZER);
+}
+
+void beepPause() {
+  tone(AL_BUZZER, 500, 150);  // 500Hz tone for 150ms
+  delay(200);
+  noTone(AL_BUZZER);
+}
+
+void beepReset() {
+  tone(AL_BUZZER, 800, 100);
+  delay(150);
+  tone(AL_BUZZER, 600, 100);
+  delay(150);
+  noTone(AL_BUZZER);
+}
+
+void showStatus(String state) {
+  digitalWrite(AL_LED_GREEN, LOW);
+  digitalWrite(AL_LED_YELLOW, LOW);
+  digitalWrite(AL_LED_RED, LOW);
+
+  if (state == "running") {
+    digitalWrite(AL_LED_GREEN, HIGH);
+  } else if (state == "paused") {
+    digitalWrite(AL_LED_YELLOW, HIGH);
+  } else {
+    digitalWrite(AL_LED_RED, HIGH);
+  }
+}

--- a/examples/serial-timer/serial-timer.ino
+++ b/examples/serial-timer/serial-timer.ino
@@ -1,0 +1,178 @@
+/**
+ * Title: Serial Countdown 
+ * Description: * A functional timer using only the onboard components of the AlphaBoard.
+ 
+ */
+
+#include "alpha.h"
+
+enum TimerState { STOPPED,
+                  RUNNING,
+                  PAUSED,
+                  TIME_UP };
+TimerState timerState = STOPPED;
+
+unsigned long startTime = 0;
+unsigned long pausedTime = 0;
+unsigned long countdownMillis = 0;
+
+bool lastStartBtnState = HIGH;
+bool lastResetBtnState = HIGH;
+
+int lastMins = -1;
+int lastSecs = -1;
+bool showedIdleMessage = false;
+
+void setup() {
+  Serial.begin(9600);
+
+  pinMode(AL_BUTTON_A4, INPUT_PULLUP);  // Start/Pause/Resume
+  pinMode(AL_BUTTON_A5, INPUT_PULLUP);  // Reset
+
+  pinMode(AL_LED_RED, OUTPUT);
+  pinMode(AL_LED_YELLOW, OUTPUT);
+  pinMode(AL_LED_GREEN, OUTPUT);
+  pinMode(AL_BUZZER, OUTPUT);
+
+  showState();
+
+  Serial.println("⏱️ TIMER READY");
+  Serial.println("🔧 Use POT A1 for minutes, POT A2 for seconds.");
+  Serial.println("▶️ Press A4 to START. ⏸️ Press again to PAUSE. ▶️ Press again to RESUME.");
+  Serial.println("🔁 Press A5 to RESET.");
+}
+
+void loop() {
+  bool startBtn = digitalRead(AL_BUTTON_A4);
+  bool resetBtn = digitalRead(AL_BUTTON_A5);
+
+  // Handle STOPPED state — set time from potentiometer
+  if (timerState == STOPPED) {
+    int mins = map(analogRead(AL_POT_A1), 0, 1023, 0, 59);
+    int secs = map(analogRead(AL_POT_A2), 0, 1023, 0, 59);
+
+    if (mins != lastMins || secs != lastSecs) {
+      countdownMillis = (mins * 60UL + secs) * 1000UL;
+      printTime(countdownMillis);
+      lastMins = mins;
+      lastSecs = secs;
+      showedIdleMessage = false;
+    } else if (!showedIdleMessage) {
+      Serial.println("🛑 Timer ready. Press A4 to start or adjust pots to change time.");
+      showedIdleMessage = true;
+    }
+  }
+
+  // Start / Pause / Resume Button (A4)
+  if (startBtn == LOW && lastStartBtnState == HIGH) {
+    delay(50);  // debounce
+    if (timerState == STOPPED && countdownMillis > 0) {
+      countdownStartup();  // 3-second beep+blink countdown
+      startTime = millis();
+      timerState = RUNNING;
+      beep(1);
+      Serial.println("✅ Timer started.");
+    } else if (timerState == RUNNING) {
+      pausedTime = millis();
+      timerState = PAUSED;
+      beep(1);
+      Serial.println("⏸️ Timer paused.");
+    } else if (timerState == PAUSED) {
+      startTime += millis() - pausedTime;
+      timerState = RUNNING;
+      beep(1);
+      Serial.println("▶️ Timer resumed.");
+    } else if (timerState == TIME_UP) {
+      startTime = millis();
+      timerState = RUNNING;
+      beep(1);
+      Serial.println("🔁 Restarting timer.");
+    }
+    showState();
+  }
+  lastStartBtnState = startBtn;
+
+  // Reset Button (A5)
+  if (resetBtn == LOW && lastResetBtnState == HIGH) {
+    delay(50);  // debounce
+    timerState = STOPPED;
+    countdownMillis = 0;
+    beep(2);
+    Serial.println("🔁 Timer reset.");
+    showState();
+  }
+  lastResetBtnState = resetBtn;
+
+  // Countdown display
+  if (timerState == RUNNING) {
+    unsigned long elapsed = millis() - startTime;
+    if (elapsed < countdownMillis) {
+      printTime(countdownMillis - elapsed);
+    } else {
+      timerState = TIME_UP;
+      Serial.println("⏰ TIME'S UP! Press A4 to restart or A5 to reset.");
+      showState();
+    }
+  }
+
+  // Continuous buzzer tone during TIME_UP
+  if (timerState == TIME_UP) {
+    tone(AL_BUZZER, 1000);  // 1kHz tone
+  } else {
+    noTone(AL_BUZZER);
+  }
+
+  delay(100);
+}
+
+// Display MM:SS on Serial
+void printTime(unsigned long msLeft) {
+  int totalSec = msLeft / 1000;
+  int mm = totalSec / 60;
+  int ss = totalSec % 60;
+  Serial.print("⏳ Time Left: ");
+  if (mm < 10) Serial.print("0");
+  Serial.print(mm);
+  Serial.print(":");
+  if (ss < 10) Serial.print("0");
+  Serial.println(ss);
+}
+
+// Beep n times
+void beep(int count) {
+  for (int i = 0; i < count; i++) {
+    digitalWrite(AL_BUZZER, HIGH);
+    delay(100);
+    digitalWrite(AL_BUZZER, LOW);
+    delay(150);
+  }
+}
+
+// Update LED state
+void showState() {
+  digitalWrite(AL_LED_RED, timerState == STOPPED);
+  digitalWrite(AL_LED_YELLOW, timerState == PAUSED);
+  digitalWrite(AL_LED_GREEN, timerState == RUNNING || timerState == TIME_UP);
+
+  Serial.print("📟 Status: ");
+  if (timerState == STOPPED) Serial.println("STOPPED");
+  if (timerState == PAUSED) Serial.println("PAUSED");
+  if (timerState == RUNNING) Serial.println("RUNNING");
+  if (timerState == TIME_UP) Serial.println("TIME'S UP");
+}
+
+// 3-second startup countdown with buzzer + LED blink
+void countdownStartup() {
+  Serial.println("⏳ Starting in:");
+  for (int i = 3; i >= 1; i--) {
+    Serial.print(i);
+    Serial.println("...");
+    digitalWrite(AL_LED_YELLOW, HIGH);
+    digitalWrite(AL_BUZZER, HIGH);
+    delay(300);
+    digitalWrite(AL_LED_YELLOW, LOW);
+    digitalWrite(AL_BUZZER, LOW);
+    delay(700);
+  }
+  Serial.println("▶️ Go!");
+}


### PR DESCRIPTION
# ⏱️ Add Fully Functional Countdown Timer Using Serial, Potentiometerss, Buttons, LEDs, and Buzzer

## 🧩 Summary

This countdown timer example uses the AlphaBoard's onboard components only. The sketch is designed for ease of use, educational value, and full integration with the AlphaBoard platform. 

## ✅ Features

- **Time Setting via Potentiometers**
  - `AL_POT_A1` → Minutes (0–59)
  - `AL_POT_A2` → Seconds (0–59)

- **Controls via Buttons**
  - `AL_BUTTON_A4` → Start / Pause / Resume / Restart
  - `AL_BUTTON_A5` → Reset

- **Output and Feedback**
  - **Serial Monitor**
    - Live MM:SS display
    - State change messages
  - **LED Indicators**
    - 🟢 Green → Running
    - 🟡 Yellow → Paused
    - 🔴 Red → Stopped / Reset
  - **Buzzer Feedback**
    - Single beep → Start / Pause / Resume
    - Double beep → Reset
    - Continuous tone → Time’s up
    - 3-second startup countdown → Short beep + blinking yellow LED


